### PR TITLE
raw data compatibility

### DIFF
--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -218,7 +218,7 @@ void HttpServer::HandleHttpData(const EventData &raw_request,
   // Set response to write to client
   response_string =
       to_string(http_response, http_request.method() != HttpMethod::HEAD);
-  strncpy(raw_response->buffer, response_string.c_str(), kMaxBufferSize);
+  memcpy(raw_response->buffer, response_string.c_str(), kMaxBufferSize);
   raw_response->length = response_string.length();
 }
 


### PR DESCRIPTION
strncpy doesn't copy bytes after a null byte. memcpy does.